### PR TITLE
Fix Nucleus Model Server for Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Some of Nucleus's features include:
 <!-- UPDATE THIS VERSION ON EACH RELEASE (it's better than using "master") -->
 
 ```bash
-pip install git+https://github.com/cortexlabs/nucleus.git@0.2.1
+pip install git+https://github.com/cortexlabs/nucleus.git@0.2.2
 ```
 
 ## Example usage

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ env:  # environment variables to be exported to the model server (optional)
 config:  # dictionary config to be passed to the model server's constructor (optional)
   # <string: value>  # arbitrary dictionary passed to the constructor of the Handler class
 python_path: <string>  # path to the root of your Python folder that will be appended to PYTHONPATH (default: folder containing the model server config) (required)
+path: <string>  # path to the Python handler script containing the Handler class relative to the <python_path> path (required)
 protobuf_path: <string>  # path to a protobuf file relative to your project dir (required if using gRPC)
 models: # use this to serve one or more models with live reloading for the tensorflow type (required for tensorflow type, not supported for python type)
   path: <string>  # S3 path to an exported model directory (e.g. s3://my-bucket/exported_model/) (either this, 'dir', or 'paths' must be provided if 'models' is specified)

--- a/nucleus/templates/handler.Dockerfile
+++ b/nucleus/templates/handler.Dockerfile
@@ -35,7 +35,7 @@ RUN curl "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.s
     rm -rf ~/.cache ~/miniconda.sh
 
 # split the conda installations to reduce memory usage when building the image
-RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip=19.* && \
+RUN /opt/conda/bin/conda create -n env -c conda-forge python=$PYTHONVERSION pip && \
     /opt/conda/bin/conda clean -a && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" > ~/.env && \

--- a/src/cortex/cortex_internal.requirements.txt
+++ b/src/cortex/cortex_internal.requirements.txt
@@ -1,7 +1,7 @@
 grpcio==1.36.0
 boto3==1.14.53
 dill>=0.3.1.1
-jinja2==2.11.3
+jinja2==3.1.2
 fastapi==0.61.1
 pyyaml==5.4
 python-json-logger==2.0.1


### PR DESCRIPTION
This PR brings the following fixes:

* The `path` field in the model server config isn't present. This is bad because it's a required field.
* Remove lock on pip version - version 19.* doesn't work in Python 3.9.
* Update Jinja2 to prevent getting import errors on Python 3.9.